### PR TITLE
Make info_button insensitive if url_input has no text

### DIFF
--- a/src/vido.vala
+++ b/src/vido.vala
@@ -53,10 +53,13 @@ public static int main(string[] args) {
   url_input.changed.connect (() => {
     string url_input_text = url_input.text;
     if (url_input_text.length > 1) {
+      info_button.sensitive = true;
       if (has_location) {
         download_button.set_sensitive (true);
       }
       has_input = true;
+    } else {
+      info_button.sensitive = false;
     }
   });
   // Add a delete-button:
@@ -119,6 +122,7 @@ public static int main(string[] args) {
   grid.attach (video_label, 0, 3, 75, 1);
 
   // Get info button
+  info_button.sensitive = false;
   info_button.clicked.connect (() => {
     string str = _("Loading info…");
     info_button.label = str;


### PR DESCRIPTION
A small usability fix.

### Before

![peek 2019-02-13 21-21](https://user-images.githubusercontent.com/26003928/52712594-6bd3e100-2fd8-11e9-9345-279e3b6e8dd7.gif)

If a user clicks `info_button` when `url_input` has no string, an error is show because there's no valid URL.

### After

![peek 2019-02-13 21-39](https://user-images.githubusercontent.com/26003928/52712597-6eced180-2fd8-11e9-8129-f3616c44610a.gif)

`info_button` is insensitive when `url_input` has no string.
