### PR TITLE
Avoid the window gets too big due to error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Download online videos from various sources including archive.org and much more!
 Please make sure you have these dependencies first before building.
 
 ```
-gtk+-3.0
 glib-2.0
+granite
+gtk+-3.0
 youtube-dl
 ```
 To build locally:

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,8 @@ executable(
     ],
     dependencies: [
         dependency('glib-2.0'),
-        dependency('gtk+-3.0')
+        dependency('gtk+-3.0'),
+        dependency('granite')
     ],
     install: true
 )

--- a/src/vido.vala
+++ b/src/vido.vala
@@ -160,7 +160,17 @@ public static int main(string[] args) {
 
       ChildWatch.add (child_pid, (pid, status) => {
         // Triggered when the child indicated by child_pid exits
-        video_label.label = video_info;
+        if (status == 0) {
+          video_label.label = video_info;
+        } else {
+          video_label.label = "";
+          var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (_("Unable to fetch the video info"), _("The following error message may be helpful:"), "dialog-error");
+          error_dialog.transient_for = window;
+          error_dialog.show_error_details (video_info);
+          error_dialog.run ();
+          error_dialog.destroy ();
+        }
+        video_info = ""; // Clear the video info (or the error message)
         info_button.label = _("Get Video Info");
         Process.close_pid (pid);
         loop.quit ();


### PR DESCRIPTION
![screen record from 2019-02-18 14 13 33](https://user-images.githubusercontent.com/26003928/52929626-874c3c80-3388-11e9-8a4b-367ff0c135f8.gif)

Fixes the window gets too big due to error messages like NathanBnm's screenshot in  https://github.com/bernardodsanderson/vido/issues/30#issuecomment-463345662.

The `show_error_expander` method in `Granite.MessageDialog` [seems to wrap details texts automatically](https://github.com/elementary/granite/blob/c6f47f11356c7241e31476336c9278b3c48d598a/lib/Widgets/MessageDialog.vala#L303). Also, not only the use of this dialog fixes this issue, but also attracts user's attention. So I think this is even better.
