### PR TITLE
Fix sensitivity of download_button

### DIFF
--- a/src/vido.vala
+++ b/src/vido.vala
@@ -52,7 +52,7 @@ public static int main(string[] args) {
   url_input.set_placeholder_text (_("Enter URL…"));
   url_input.changed.connect (() => {
     string url_input_text = url_input.text;
-    if (url_input_text.length > 1) {
+    if (url_input_text != "") {
       info_button.sensitive = true;
       if (has_location) {
         download_button.set_sensitive (true);
@@ -60,6 +60,7 @@ public static int main(string[] args) {
       has_input = true;
     } else {
       info_button.sensitive = false;
+      download_button.sensitive = false;
     }
   });
   // Add a delete-button:


### PR DESCRIPTION
### BEFORE

![2019-03-28 20 56 50 の画面録画](https://user-images.githubusercontent.com/26003928/55156092-62739200-519c-11e9-853c-dd6de155de57.gif)

### AFTER

![2019-03-28 20 57 39 の画面録画](https://user-images.githubusercontent.com/26003928/55156093-62739200-519c-11e9-96ea-75fe2908de02.gif)

### Changes Summary

* Fix download_button is not sensitive when url_input has only one word (Fixes #28)
* Fix download_button remains sensitive when users clear the content of url_input with Backspace key
