### PR TITLE
Remove unneeded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-src/vido
 build

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,6 @@ asresources = gnome.compile_resources(
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install
 executable(
     meson.project_name(),
-    'src/config.vala',
     'src/vido.vala',
     asresources,
     vala_args: [

--- a/src/config.vala
+++ b/src/config.vala
@@ -1,4 +1,0 @@
-namespace Constants {
-    public const string DATADIR = "/usr/share";
-    public const string PKGDATADIR = "/usr/share/com.github.bernardodsanderson.vido";
-}

--- a/src/config.vala.cmake
+++ b/src/config.vala.cmake
@@ -1,4 +1,0 @@
-namespace Constants {
-    public const string DATADIR = "@DATADIR@";
-    public const string PKGDATADIR = "@PKGDATADIR@";
-}


### PR DESCRIPTION
## Changes Summary

* Remove `src/vido` from `.gitignore`, because we've already set up the build system and no longer use `valac` command directory
* Remove `src/config.vala` and `src/config.vala.cmake`, because the declared variables are not used in any code
