### PR TITLE
Fix thick titlebar on GTK 3.22 or later

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -37,6 +37,7 @@ public class MainWindow : Gtk.ApplicationWindow {
         // Header
         var header = new Gtk.HeaderBar ();
         header.show_close_button = true;
+        header.has_subtitle = false;
         header.title = _("VIDO - Video Downloader");
         set_titlebar (header);
 


### PR DESCRIPTION
## BEFORE
![Screenshot from 2019-12-05 22-45-22](https://user-images.githubusercontent.com/26003928/70240647-f1678e00-17b0-11ea-97cb-baac7f252330.png)

## AFTER
![Screenshot from 2019-12-05 22-44-39](https://user-images.githubusercontent.com/26003928/70240646-f1678e00-17b0-11ea-9364-0003e3d8ba2d.png)
