### PR TITLE
Add a clear icon only when there are some text(s) in the entry

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -46,10 +46,16 @@ public class MainWindow : Gtk.ApplicationWindow {
         var url_input = new Gtk.Entry ();
         url_input.get_style_context ().add_class ("inputurl");
         url_input.placeholder_text = _("Enter URL…");
-
-        // Add a clear icon
-        url_input.secondary_icon_name = "edit-clear-symbolic";
         url_input.input_purpose = Gtk.InputPurpose.URL;
+
+        // Add a clear icon only when there are some text(s) in the entry
+        url_input.changed.connect (() => {
+            if (url_input.text != "") {
+                url_input.secondary_icon_name = "edit-clear-symbolic";
+            } else {
+                url_input.secondary_icon_name = null;
+            }
+        });
 
         // Save location button
         var location_label = new Gtk.Label (_("Folder to Save:"));


### PR DESCRIPTION
So that we can avoid ["Controls That Do Nothing" in elementary HIG](https://elementary.io/ja/docs/human-interface-guidelines#widget-concepts)

## BEFORE
![2019-12-16 21 38 24 の画面録画](https://user-images.githubusercontent.com/26003928/70907619-ad944480-204c-11ea-98af-b02842b77a09.gif)

## AFTER
![2019-12-16 21 37 21 の画面録画](https://user-images.githubusercontent.com/26003928/70907617-acfbae00-204c-11ea-95a5-4eda49a66899.gif)
