### PR TITLE
Add Japanese translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,5 +1,6 @@
-fr
-nl
-lt
-ru
 es
+fr
+ja
+lt
+nl
+ru

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,6 +1,6 @@
-es
 fr
-ja
-lt
 nl
+lt
 ru
+es
+ja

--- a/po/extra/LINGUAS
+++ b/po/extra/LINGUAS
@@ -1,5 +1,6 @@
-fr
-nl
-lt
-ru
 es
+fr
+ja
+lt
+nl
+ru

--- a/po/extra/LINGUAS
+++ b/po/extra/LINGUAS
@@ -1,6 +1,6 @@
-es
 fr
-ja
-lt
 nl
+lt
 ru
+es
+ja

--- a/po/extra/ja.po
+++ b/po/extra/ja.po
@@ -1,7 +1,7 @@
 # Japanese translations for extra package.
 # Copyright (C) 2019 THE extra'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the extra package.
-# Automatically generated, 2019.
+# Ryo Nakano <ryonakaknock3@gmail.com>, 2019.
 #
 msgid ""
 msgstr ""

--- a/po/extra/ja.po
+++ b/po/extra/ja.po
@@ -1,0 +1,130 @@
+# Japanese translations for extra package.
+# Copyright (C) 2019 THE extra'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the extra package.
+# Automatically generated, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: extra\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-12-16 21:49+0900\n"
+"PO-Revision-Date: 2019-12-16 21:52+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.2.4\n"
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:7
+#: data/com.github.bernardodsanderson.vido.desktop.in:3
+msgid "VIDO"
+msgstr "VIDO"
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:8
+msgid "Online Video Downloader"
+msgstr "オンライン動画のダウンロードアプリ"
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:10
+msgid ""
+"Download online videos from various sources including archive.org and much "
+"more!"
+msgstr ""
+"archive.org などのさまざまなソースに掲載されているオンライン動画をダウンロー"
+"ドできます！"
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:15
+msgid "Spanish Translation (thanks riesp)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:16
+msgid "Travis CI integration (thanks meisenzahl)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:21
+msgid "App refactoring (thanks ryonakano)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:26
+msgid "Translation Updates"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:27
+msgid "Add Lithuanian translation (thanks welaq)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:28
+msgid "Fix sensitivity of download_button (thanks ryonakano)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:29
+msgid "Update French translation (thanks NathanBnm)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:30
+msgid "Remove unneeded files (thanks ryonakano)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:35
+msgid "Update app category"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:36
+msgid "Fix window getting too big due to error messages (thank you ryonakano)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:41
+msgid "Add Russian translation (thank you camellan)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:42
+msgid "Add French translation (thank you NathanBnm)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:43
+msgid ""
+"Make 'Get Video Info' button will be disabled if there's no url (thank you "
+"ryonakano)"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:48
+msgid "Make App Translatable"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:49
+msgid "Add License"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:54
+msgid "Fix audio download issues"
+msgstr ""
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:68
+msgid "Normal Mode"
+msgstr "通常モード"
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:72
+msgid "Ready to Download"
+msgstr "ダウンロード準備完了"
+
+#: data/com.github.bernardodsanderson.vido.appdata.xml.in:76
+msgid "Bernardo Anderson"
+msgstr "Bernardo Anderson"
+
+#: data/com.github.bernardodsanderson.vido.desktop.in:4
+msgid "VIDO - Video Downloader"
+msgstr "VIDO - Video Downloader"
+
+#: data/com.github.bernardodsanderson.vido.desktop.in:5
+msgid "Download Videos from the Internet"
+msgstr "インターネットから動画をダウンロードします"
+
+#: data/com.github.bernardodsanderson.vido.desktop.in:8
+msgid "com.github.bernardodsanderson.vido"
+msgstr "com.github.bernardodsanderson.vido"
+
+#: data/com.github.bernardodsanderson.vido.desktop.in:11
+msgid "Video;Download;Internet;"
+msgstr "Video;Download;Internet;動画;ビデオ;ダウンロード;インターネット;"

--- a/po/extra/ja.po
+++ b/po/extra/ja.po
@@ -115,7 +115,7 @@ msgstr "Bernardo Anderson"
 
 #: data/com.github.bernardodsanderson.vido.desktop.in:4
 msgid "VIDO - Video Downloader"
-msgstr "VIDO - Video Downloader"
+msgstr "VIDO - 動画ダウンロードアプリ"
 
 #: data/com.github.bernardodsanderson.vido.desktop.in:5
 msgid "Download Videos from the Internet"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,82 @@
+# Japanese translations for com.github.bernardodsanderson.vido package.
+# Copyright (C) 2019 THE com.github.bernardodsanderson.vido'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the com.github.bernardodsanderson.vido package.
+# Automatically generated, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.github.bernardodsanderson.vido\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-12-16 21:44+0900\n"
+"PO-Revision-Date: 2019-12-16 21:49+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.2.4\n"
+
+#: src/MainWindow.vala:42
+msgid "VIDO - Video Downloader"
+msgstr "VIDO - 動画ダウンロードアプリ"
+
+#: src/MainWindow.vala:48
+msgid "Enter URL…"
+msgstr "URL を入力…"
+
+#. Save location button
+#: src/MainWindow.vala:55
+msgid "Folder to Save:"
+msgstr "保存先のフォルダー:"
+
+#: src/MainWindow.vala:57
+msgid "Select Folder to Save"
+msgstr "保存先のフォルダーを選択してください"
+
+#. Audio Only
+#: src/MainWindow.vala:62
+msgid "Audio Only"
+msgstr "音声のみ"
+
+#. With Subtitles
+#: src/MainWindow.vala:65
+msgid "Add Subtitles"
+msgstr "字幕を追加"
+
+#. Get info button
+#. Clear the video info (or the error message)
+#: src/MainWindow.vala:73 src/MainWindow.vala:111 src/MainWindow.vala:201
+msgid "Get Video Info"
+msgstr "動画の情報を取得"
+
+#. download_button button
+#: src/MainWindow.vala:77 src/MainWindow.vala:114 src/MainWindow.vala:266
+msgid "Download"
+msgstr "ダウンロード"
+
+#: src/MainWindow.vala:149
+msgid "Loading info…"
+msgstr "情報を読み込んでいます…"
+
+#: src/MainWindow.vala:191
+msgid "Unable to fetch the video info"
+msgstr "動画の情報を取得できません"
+
+#: src/MainWindow.vala:192 src/MainWindow.vala:270
+msgid "The following error message may be helpful:"
+msgstr "以下のエラーメッセージが役に立つ可能性があります:"
+
+#: src/MainWindow.vala:213
+msgid "Downloading…"
+msgstr "ダウンロードしています…"
+
+#. Triggered when the child indicated by child_pid exits
+#: src/MainWindow.vala:263
+msgid "Finished!"
+msgstr "完了しました！"
+
+#: src/MainWindow.vala:269
+msgid "Unable to download the video"
+msgstr "動画をダウンロードできません"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,7 +1,7 @@
 # Japanese translations for com.github.bernardodsanderson.vido package.
 # Copyright (C) 2019 THE com.github.bernardodsanderson.vido'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.bernardodsanderson.vido package.
-# Automatically generated, 2019.
+# Ryo Nakano <ryonakaknock3@gmail.com>, 2019.
 #
 msgid ""
 msgstr ""


### PR DESCRIPTION
So I translated your app into Japanese finally! :tada:

![Screenshot from 2019-12-16 21-54-58](https://user-images.githubusercontent.com/26003928/70908657-0533af80-204f-11ea-8e30-c04bd6616d3a.png)

![Screenshot from 2019-12-16 21-54-22](https://user-images.githubusercontent.com/26003928/70908656-0533af80-204f-11ea-8c69-2598fb0ad023.png)

I did not add translations for release notes in the `extra` translation, because they won't be shown anywhere.

## Changes Summary
* Add Japanese translation
* Sort `LINGUAS` alphabetically
