### PR TITLE
Fix appdata parse error

### DIFF
--- a/data/com.github.bernardodsanderson.vido.appdata.xml.in
+++ b/data/com.github.bernardodsanderson.vido.appdata.xml.in
@@ -11,59 +11,60 @@
   </description>
   ​<releases>
     <release version="2.0.0" date="2021-09-26" urgency="high">
-  ​    <description>
+      <description>
         <p>Updated for elementary OS 6</p>
       </description>
-  ​  </release>
+    </release>
     <release version="1.3.1" date="2019-12-04" urgency="low">
-  ​    <description>
+      <description>
         <p>Spanish Translation (thanks riesp)</p>
         <p>Travis CI integration (thanks meisenzahl)</p>
       </description>
-  ​  </release>
+    </release>
     <release version="1.3.0" date="2019-06-23" urgency="low">
-  ​    <description>
+      <description>
         <p>App refactoring (thanks ryonakano)</p>
       </description>
-  ​  </release>
+    </release>
     <release version="1.2.8" date="2019-06-05" urgency="low">
-  ​    <description>
+      <description>
         <p>Translation Updates</p>
         <p>Add Lithuanian translation (thanks welaq)</p>
         <p>Fix sensitivity of download_button (thanks ryonakano)</p>
         <p>Update French translation (thanks NathanBnm)</p>
         <p>Remove unneeded files (thanks ryonakano)</p>
       </description>
-  ​  </release>
+    </release>
     <release version="1.2.7" date="2019-03-01" urgency="low">
-  ​    <description>
+      <description>
         <p>Update app category</p>
         <p>Fix window getting too big due to error messages (thank you ryonakano)</p>
       </description>
-  ​  </release>
+    </release>
     <release version="1.2.4" date="2019-02-16" urgency="low">
-  ​    <description>
+      <description>
         <p>Add Russian translation (thank you camellan)</p>
         <p>Add French translation (thank you NathanBnm)</p>
         <p>Make 'Get Video Info' button will be disabled if there's no url (thank you ryonakano) </p>
       </description>
-  ​  </release>
+    </release>
     <release version="1.2.3" date="2019-02-11" urgency="low">
-  ​    <description>
+      <description>
         <p>Make App Translatable</p>
         <p>Add License</p>
       </description>
-  ​  </release>
-  ​  <release version="1.2.2" date="2019-01-10" urgency="medium">
-  ​    <description>
+    </release>
+    <release version="1.2.2" date="2019-01-10" urgency="medium">
+      <description>
         <p>Fix audio download issues</p>
       </description>
-  ​  </release>
-  ​</releases>
+    </release>
+  </releases>
   <custom>
-     <value key="x-appcenter-color-primary">#F2C94C</value>
-     <value key="x-appcenter-color-primary-text">#333</value>
-     <value key="x-appcenter-suggested-price">1</value>
+    <value key="x-appcenter-color-primary">#F2C94C</value>
+    <value key="x-appcenter-color-primary-text">#333</value>
+    <value key="x-appcenter-suggested-price">1</value>
+    <value key="x-appcenter-stripe">pk_live_STtcXII2pdHg9Yas7q6olWZl</value>
   </custom>
   <provides>
     <binary>com.github.bernardodsanderson.vido</binary>
@@ -81,5 +82,4 @@
   <developer_name>Bernardo Anderson</developer_name>
   <url type="homepage">http://github.com/bernardodsanderson/vido</url>
   <url type="bugtracker">https://github.com/bernardodsanderson/vido/issues</url>
-  <value key="x-appcenter-stripe">pk_live_STtcXII2pdHg9Yas7q6olWZl</value>
 </component>


### PR DESCRIPTION
Fix building in Flatpak fails with the following erorr:

```
Error loading AppData file: failed to parse /app/share/appdata/com.github.bernardodsanderson.vido.appdata.xml: Error on line 6 char 9: <release> already set '​' and tried to replace with '
  ​  '
Error: ERROR: appstream-compose failed: child process failed, exited with error number 1
```

Also move the stripe key to the correct place :wink:
