### PR TITLE
Download youtube-dl on installation

### DIFF
--- a/com.github.bernardodsanderson.vido.yml
+++ b/com.github.bernardodsanderson.vido.yml
@@ -1,31 +1,25 @@
-# This is the same ID that you've used in meson.build and other files
 app-id: com.github.bernardodsanderson.vido
-
-# Instead of manually specifying a long list of build and runtime dependencies,
-# we can use a convenient pre-made runtime and SDK. For this example, we'll be
-# using the runtime and SDK provided by elementary.
 runtime: io.elementary.Platform
 runtime-version: '6'
 sdk: io.elementary.Sdk
-
-# This should match the exec line in your .desktop file and usually is the same
-# as your app ID
 command: com.github.bernardodsanderson.vido
-
-# Here we can specify the kinds of permissions our app needs to run. Since we're
-# not using hardware like webcams, making sound, or reading external files, we
-# only need permission to draw our app on screen using either X11 or Wayland.
 finish-args:
   - '--share=ipc'
   - '--socket=fallback-x11'
   - '--socket=wayland'
-
-# This section is where you list all the source code required to build your app.
-# If we had external dependencies that weren't included in our SDK, we would list
-# them here.
+  - '--share=network'
 modules:
   - name: vido
     buildsystem: meson
     sources:
       - type: dir
         path: .
+  - name: youtube-dl
+    buildsystem: simple
+    build-options:
+      build-args:
+        - '--share=network'
+    build-commands:
+      - curl -vL https://yt-dl.org/downloads/latest/youtube-dl -o $FLATPAK_DEST/bin/youtube-dl
+      - chmod a+rx $FLATPAK_DEST/bin/youtube-dl
+      - alias youtube-dl=\'$FLATPAK_DEST/bin/youtube-dl\'


### PR DESCRIPTION
Your app uses `youtube-dl` but since now it's sandboxed with Flatpak, the app can't use the locally installed version of `youtube-dl`. We need to download it in the sandboxed environement instead
