### PR TITLE
Less scope in Flatpak, fix folder selection, and fix merging into mkv

### DIFF
--- a/com.github.bernardodsanderson.vido.yml
+++ b/com.github.bernardodsanderson.vido.yml
@@ -10,7 +10,7 @@ finish-args:
   # For downloading videos
   - '--share=network'
   # For saving location
-  - '--filesystem=home'
+  - '--filesystem=xdg-download'
 modules:
   - name: vido
     buildsystem: meson

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -62,7 +62,7 @@ public class MainWindow : Gtk.ApplicationWindow {
         location_label.halign = Gtk.Align.END;
         var location_button = new Gtk.FileChooserButton (_("Select Folder to Save"), Gtk.FileChooserAction.SELECT_FOLDER);
         location_button.halign = Gtk.Align.START;
-        location_button.set_filename (get_destination ());
+        location_button.set_current_folder (get_destination ());
 
         // Audio Only
         var audio_only = new Gtk.CheckButton.with_label (_("Audio Only"));
@@ -125,12 +125,11 @@ public class MainWindow : Gtk.ApplicationWindow {
         });
 
         location_button.file_set.connect (() => {
-            Application.settings.set_string ("destination", location_button.get_filename ());
+            folder_location = location_button.get_filename ();
+            Application.settings.set_string ("destination", folder_location);
 
-            if (folder_location != "") {
-                if (url_input.text != "") {
-                    download_button.sensitive = true;
-                }
+            if (url_input.text != "") {
+                download_button.sensitive = true;
             }
         });
 
@@ -295,10 +294,16 @@ public class MainWindow : Gtk.ApplicationWindow {
 
     private string get_destination () {
         string destination = Application.settings.get_string ("destination");
+        if (destination == "") {
+            destination = Environment.get_user_special_dir (UserDirectory.DOWNLOAD);
+            Application.settings.set_string ("destination", destination);
+        }
 
         if (destination != null) {
             DirUtils.create_with_parents (destination, 0775);
         }
+
+        folder_location = destination;
 
         return destination;
     }


### PR DESCRIPTION
* Allow access only to `Downloads` instead of entire home directory (fixes #68)
* Fix selected destination not being saved to GSettings
* Fix merging downloaded audio and video files into a single mkv file failing
