### PR TITLE
MainWindow: Correctly set the app title

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -23,7 +23,8 @@ public class MainWindow : Hdy.Window {
     public MainWindow (Gtk.Application app) {
         Object (
             application: app,
-            resizable: false
+            resizable: false,
+            title: "VIDO"
         );
     }
 
@@ -40,7 +41,7 @@ public class MainWindow : Hdy.Window {
         var header = new Hdy.HeaderBar () {
             show_close_button = true,
             has_subtitle = false,
-            title = _("VIDO - Video Downloader")
+            title = "VIDO"
         };
         header.get_style_context ().add_class (Granite.STYLE_CLASS_DEFAULT_DECORATION);
         header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);


### PR DESCRIPTION
## Before
![2021-12-03 15 48 07 のスクリーンショット](https://user-images.githubusercontent.com/26003928/144558771-a573ac32-89e6-4c4b-b9e6-1c28c76529ab.png)

The RDNN name of the app is shown in Multitasking View.

## After
![2021-12-03 15 52 01 のスクリーンショット](https://user-images.githubusercontent.com/26003928/144558777-57eeab54-6a33-41ff-90a5-16c3ef8d1183.png)

Simply the actual app name is shown in Multitasking View. Also omit the word of "Video Downloader" from the headerbar's title because I think users may not care about what the app name "VIDO" derived from, although this is not written in [the elementary OS HIG](https://docs.elementary.io/hig/widgets/container-widgets#window-tiles).

And disallow translating the app name "VIDO" because it's a proper noun.
