### PR TITLE
Update to elementary OS Platform 8 and modernize dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:6
+      image: ghcr.io/elementary/flatpak-platform/runtime:8
       options: --privileged
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
-        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: vido.flatpak
           manifest-path: com.github.bernardodsanderson.vido.yml

--- a/com.github.bernardodsanderson.vido.yml
+++ b/com.github.bernardodsanderson.vido.yml
@@ -1,6 +1,6 @@
 app-id: com.github.bernardodsanderson.vido
 runtime: io.elementary.Platform
-runtime-version: '6'
+runtime-version: '8'
 sdk: io.elementary.Sdk
 command: com.github.bernardodsanderson.vido
 finish-args:
@@ -17,13 +17,13 @@ modules:
     sources:
       - type: dir
         path: .
-  - name: youtube-dl
+  - name: yt-dlp
     buildsystem: simple
     build-options:
       build-args:
-        # For downloading youtube-dl itself
+        # For downloading yt-dlp itself
         - '--share=network'
     build-commands:
-      - curl -vL https://yt-dl.org/downloads/latest/youtube-dl -o $FLATPAK_DEST/bin/youtube-dl
-      - chmod a+rx $FLATPAK_DEST/bin/youtube-dl
-      - alias youtube-dl=\'$FLATPAK_DEST/bin/youtube-dl\'
+      - curl -vL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o $FLATPAK_DEST/bin/yt-dlp
+      - chmod a+rx $FLATPAK_DEST/bin/yt-dlp
+      - ln -s $FLATPAK_DEST/bin/yt-dlp $FLATPAK_DEST/bin/youtube-dl # Add symlink for compatibility


### PR DESCRIPTION
- Updated Flatpak runtime and SDK to version 8.
- Replaced bundled youtube-dl with yt-dlp for improved video downloading.
- Updated GitHub Actions workflow to use Platform 8 runtime and newer action versions.
- Reviewed Granite and LibHandy dependencies; kept existing versions for GTK3 compatibility, noting future migration paths to GTK4/LibAdwaita.

Local Flatpak build testing was inconclusive due to sandbox environment limitations regarding seccomp/bwrap.